### PR TITLE
Update upgrade docs for python2-iml-agent module

### DIFF
--- a/docs/Upgrade_Guide/Upgrade_EE-2.4-el6_to_LU-LTS-el7.md
+++ b/docs/Upgrade_Guide/Upgrade_EE-2.4-el6_to_LU-LTS-el7.md
@@ -298,17 +298,6 @@ Also note that the manager server distribution includes a default repository def
     ```bash
     hn=`hostname --fqdn`
     cat >/var/lib/chroma/repo/Manager-for-Lustre.repo <<__EOF
-    [iml-agent]
-    name=Intel Manager for Lustre Agent
-    baseurl=https://$hn/repo/iml-agent/7
-    enabled=1
-    gpgcheck=0
-    sslverify = 1
-    sslcacert = /var/lib/chroma/authority.crt
-    sslclientkey = /var/lib/chroma/private.pem
-    sslclientcert = /var/lib/chroma/self.crt
-    proxy=_none_
-
     [lustre-server]
     name=lustre-server
     baseurl=https://$hn/repo/lustre-server
@@ -571,7 +560,7 @@ The `pcs config export` command can be useful as a cross reference when restorin
 1. Install The Intel® Manager for Lustre\* Agent and Diagnostics packages
 
     ```bash
-    yum -y install chroma-\*
+    yum -y install python2-iml-agent\*
     ```
 
     **Note:** following warning during install / update is benign and can be ignored:

--- a/docs/Upgrade_Guide/Upgrade_EE-3.1-el7_to_LU-LTS-el7.md
+++ b/docs/Upgrade_Guide/Upgrade_EE-3.1-el7_to_LU-LTS-el7.md
@@ -195,17 +195,6 @@ Also note that the manager server distribution includes a default repository def
     ```bash
     hn=`hostname --fqdn`
     cat >/var/lib/chroma/repo/Manager-for-Lustre.repo <<__EOF
-    [iml-agent]
-    name=Intel Manager for Lustre Agent
-    baseurl=https://$hn/repo/iml-agent/7
-    enabled=1
-    gpgcheck=0
-    sslverify = 1
-    sslcacert = /var/lib/chroma/authority.crt
-    sslclientkey = /var/lib/chroma/private.pem
-    sslclientcert = /var/lib/chroma/self.crt
-    proxy=_none_
-
     [lustre-server]
     name=lustre-server
     baseurl=https://$hn/repo/lustre-server
@@ -396,7 +385,7 @@ The upgrade procedure documented here shows how to execute the upgrade while the
 1. Upgrade the Intel® Manager for Lustre\* Agent and Diagnostics packages
 
     ```bash
-    yum -y install chroma-\*
+    yum -y install python2-iml-agent\*
     ```
 
     **Note:** following warning during install / update is benign and can be ignored:


### PR DESCRIPTION
Update the upgrade docs to account for the changes in
the process due to the iml-agent being a separate python
available in the Copr repo now.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>