### PR TITLE
Zfs and ldiskfs

### DIFF
--- a/docs/Contributor_Docs/cd_Installing_IML_On_Vagrant.md
+++ b/docs/Contributor_Docs/cd_Installing_IML_On_Vagrant.md
@@ -75,10 +75,26 @@ This will take some time (around 20 to 30 minutes) but all four servers should a
 
 ## Configuring Interfaces
 
-Once all servers have been added, each server will need to know which interface should be assigned the lustre network. Navigate to each server detail page by clicking on the server link. Scroll to the bottom of the server detail page where you will see a list of network interfaces. Click on the `Configure` button and you will be given the option to change the network driver and the network for each interface.
+Once all servers have been added, each server will need to know which interface should be assigned the lustre network. This can be done manually or automated by a provisioning script. Select one of the methods below.
+
+### 1. Manually Configure Interfaces
+
+On the servers page, navigate to each server's detail page by clicking on the server link. Scroll to the bottom of the server detail page where you will see a list of network interfaces. Click on the `Configure` button and you will be given the option to change the network driver and the network for each interface.
 
 The vagrant file indicates that the lustre network will run on 10.73.20.x. If `Lustre Network 0` is specified for a different IP address, you will need to change its interface to `Not Lustre Network` and update the network for 10.73.20.x to use `Lustre Network 0`. It is very important that Lustre Network 0 is specified on the correct interface; otherwise, creating a filesystem will fail. Make sure that all servers have been updated where appropriate.
+
+### 2. Automatically Configure Interfaces with Provisioning Script
+
+The interfaces can be configured automatically by running the following script:
+
+```bash
+ vagrant provision mds1 mds2 oss1 oss2 --provision-with configure-lustre-network
+```
 
 ## Setting up Power Control
 
 [Follow these instructions to configure the Power Control.](cd_Setting_Up_Power_Control.md)
+
+---
+
+[Top of page](#installing-iml-on-vagrant)

--- a/docs/Contributor_Docs/cd_Installing_IML_On_Vagrant.md
+++ b/docs/Contributor_Docs/cd_Installing_IML_On_Vagrant.md
@@ -94,4 +94,3 @@ The interfaces can be configured automatically by running the following script:
 ---
 
 [Top of page](#installing-iml-on-vagrant)
-=======

--- a/docs/Contributor_Docs/cd_Monitored_Only_ZFS.md
+++ b/docs/Contributor_Docs/cd_Monitored_Only_ZFS.md
@@ -4,55 +4,9 @@
 
 ![zfs](md_Graphics/monitored_filesystem_sm.jpg)
 
-## Prerequisites:
+## Prerequisites
 
-Please refer to https://github.com/whamcloud/vagrantfiles on how to create a virtual HPC storage cluster with vagrant before attempting to install IML.
-
-## Download IML build, create zfs installer, and install zfs packages:
-
-Note: use vagrant ssh-config to get the port each server is running on. The commands below use ports that are specific to my vagrant environment.
-
-1.  Verify the following vagrant plugins are installed:
-    ```
-    vagrant plugin install vagrant-shell-commander
-    ```
-2.  Download the latest IML build (tarball).
-    from: [https://github.com/whamcloud/integrated-manager-for-lustre/releases/download/v{{site.version}}/{{site.package_name}}.tar.gz](https://github.com/whamcloud/integrated-manager-for-lustre/releases/download/v{{site.version}}/{{site.package_name}}.tar.gz)
-
-## Installing IML:
-
-1.  Copy the IML build to the /tmp directory in your admin node:
-    ```
-    scp -P 2222 ~/Downloads/{{site.package_name}}.tar.gz vagrant@127.0.0.1:/tmp/.
-    # password is "vagrant"
-    ```
-2.  ssh into the admin box and install the build:
-    ```
-    vagrant ssh
-    [vagrant@adm ~]$ sudo su - # (or "sudo -s")
-    [vagrant@adm ~]# cd /tmp
-    [vagrant@adm ~]# tar xvf <buildname>.tar.gz
-    [vagrant@adm ~]# cd <build folder>
-    [vagrant@adm ~]# ./install --no-dbspace-check
-    ```
-3.  Update the /etc/hosts file on your computer to include the following line:
-    ```
-    127.0.0.1 adm.lfs.local
-    ```
-4.  Test that a connection can be made to IML by going to the following link in your browser:
-    https://adm.lfs.local:8443
-
-## Adding and Configuring Servers
-
-You should now be able to see IML when navigating to https://adm.lfs.local:8443. Click on the login link at the top right and log in as the admin. Next, go to the server configuration page and add the following servers:
-
-```
-mds[1,2].lfs.local,oss[1,2].lfs.local
-# Make sure to select "Monitored Server Profile" for the servers profile
-```
-
-This will take some time (around 5 to 10 minutes) but all four servers should add successfully.
-There will be alerts and warnings about LNET. Ignore for now.
+Create and setup your Vagrant cluster as described in [Installing IML on Vagrant](cd_Installing_IML_On_Vagrant.md)
 
 ## Installing lustre on each MDS and OSS Server
 
@@ -72,18 +26,10 @@ ZFS can now be installed on each mds and oss node since the agent software has b
 
 ## Configuring each MDS and OSS server
 
-Each server will need to know which interface should be assigned the lustre network.
-Run the following commands:
+Configure the Lustre network on each of the servers:
 
-```
-   vagrant sh -c '
-   systemctl stop firewalld; systemctl disable firewalld;
-   systemctl start ntpd;
-   modprobe lnet
-   lnetctl lnet configure
-   lnetctl net add --net tcp0 --if enp0s9
-   /sbin/modprobe zfs;
-   genhostid' mds1 mds2 oss1 oss2
+```bash
+vagrant provision <node-name> --provision-with configure-lustre-network
 ```
 
 The IML GUI should show that the LNET and NID Configuration is updated (IP Address 10.73.20.x to use `Lustre Network 0`). All alerts are cleared.

--- a/docs/Contributor_Docs/cd_Monitored_Only_ZFS.md
+++ b/docs/Contributor_Docs/cd_Monitored_Only_ZFS.md
@@ -1,4 +1,4 @@
-# <a name="Top"></a>Creating a Monitored Only Lustre zfs Filesystem on Vagrant HPC Storage Sandbox
+# Creating a Monitored Only Lustre zfs Filesystem on Vagrant HPC Storage Sandbox
 
 [**Software Contributor Documentation Table of Contents**](cd_TOC.md)
 
@@ -8,116 +8,32 @@
 
 Create and setup your Vagrant cluster as described in [Installing IML on Vagrant](cd_Installing_IML_On_Vagrant.md)
 
-## Installing lustre on each MDS and OSS Server
+## Installing ZFS on each MDS and OSS Server
 
-ZFS can now be installed on each mds and oss node since the agent software has been deployed. To do this, follow these simple steps:
-
-1.  Create the zfs installer and install the necessary packages on the following servers: mds1, mds2, oss1, and oss2
-
-    ```
-        cd ~/downloads
-        tar xzvf {{site.package_name}}.tar.gz
-        cd {{site.package_name}}.0
-        ./create_installer zfs
-        for i in {2200..2203}; do scp -P $i ~/Downloads/{{site.package_name}}.0/lustre-zfs-el7-installer.tar.gz vagrant@127.0.0.1:/tmp/.; done
-        # password is "vagrant"
-        vagrant sh -c 'cd /tmp; sudo tar xzvf lustre-zfs-el7-installer.tar.gz; cd lustre-zfs; sudo ./install' mds1 mds2 oss1 oss2
-    ```
-
-## Configuring each MDS and OSS server
-
-Configure the Lustre network on each of the servers:
+ZFS can now be installed on each mds and oss node.
 
 ```bash
-vagrant provision <node-name> --provision-with configure-lustre-network
+vagrant provision mds1 mds2 oss1 oss2 --provision-with install-lustre-zfs
 ```
-
-The IML GUI should show that the LNET and NID Configuration is updated (IP Address 10.73.20.x to use `Lustre Network 0`). All alerts are cleared.
 
 ## Creating a monitored only zfs based Lustre filesystem
 
-The lustre filesystem will be created from the command line on zpools and IML GUI will be used to scan for the filesytem.
-Note that VM Disks (ata-VBOX_HARDDISK...) will be mapped as /dev/sd devices.
+Run the following vagrant provision script to setup the ZFS monitored only filesystem:
 
-* Management Target:
-
-```
-    vagrant ssh mds1
-    sudo -i
-    zpool create mgs -o cachefile=none /dev/disk/by-id/ata-VBOX_HARDDISK_MGS00000000000000000
-    mkfs.lustre --failover 10.73.20.12@tcp --mgs --backfstype=zfs mgs/mgt
-    zpool export mgs
+```bash
+vagrant provision mds1 mds2 oss1 oss2 --provision-with create-monitored-zfs-filesystem
 ```
 
-At this point you should wait until the volume disappears from the volumes page and the dataset appears on both the primary and secondary nodes. Then:
+After the provisioning script runs successfully, use the IML GUI to scan for the filesystem:
 
-```
-zpool import mgs
-mkdir -p /lustre/mgs
-mount -t lustre mgs/mgt /lustre/mgs
-```
+> Configuration -> Servers -> `Detect File Systems`. 
 
-* Metadata Target:
+Click the `Select All` button to select all servers and finally, click on the `Detect File Systems` button to initiate the scan. The filesystem will be listed on the `filesystems` page when the scan completes.
 
-```
-    vagrant ssh mds2
-    sudo -i
-    zpool create mds -o cachefile=none /dev/disk/by-id/ata-VBOX_HARDDISK_MDT00000000000000000
-    mkfs.lustre --failover 10.73.20.11@tcp --mdt --backfstype=zfs --fsname=zfsmo --index=0 --mgsnode=10.73.20.11@tcp mds/mdt0
-    zpool export mds
-```
+## Setting up Clients
 
-At this point you should wait until the volume disappears from the volumes page and the dataset appears on both the primary and secondary nodes. Then:
-
-```
-    zpool import mds
-    mkdir -p /lustre/zfsmo/mdt0
-    mount -t lustre mds/mdt0 /lustre/zfsmo/mdt0
-```
-
-* Object Storage Targets:
-
-```
-    vagrant ssh oss1
-    sudo -i
-    zpool create oss1 -o cachefile=none raidz2 /dev/disk/by-id/ata-VBOX_HARDDISK_OST1PORT200000000000 /dev/disk/by-id/ata-VBOX_HARDDISK_OST3PORT400000000000 /dev/disk/by-id/ata-VBOX_HARDDISK_OST5PORT600000000000 /dev/disk/by-id/ata-VBOX_HARDDISK_OST7PORT800000000000
-    mkfs.lustre --failover 10.73.20.22@tcp --ost --backfstype=zfs --fsname=zfsmo --index=0 --mgsnode=10.73.20.11@tcp oss1/ost00
-    zfs compression=on oss1
-    zpool export oss1
-```
-
-At this point you should wait until the volume disappears from the volumes page and the dataset appears on both the primary and secondary nodes. Then:
-
-```
-    zpool import oss1
-    mkdir -p /lustre/zfsmo/ost00
-    mount -t lustre oss1/ost00 /lustre/zfsmo/ost00
-```
-
-```
-    vagrant ssh oss2
-    sudo -i
-    zpool create oss2 -o cachefile=none raidz2 /dev/disk/by-id/ata-VBOX_HARDDISK_OST0PORT100000000000 /dev/disk/by-id/ata-VBOX_HARDDISK_OST2PORT300000000000 /dev/disk/by-id/ata-VBOX_HARDDISK_OST4PORT500000000000 /dev/disk/by-id/ata-VBOX_HARDDISK_OST6PORT700000000000
-    mkfs.lustre --failover  10.73.20.21@tcp --ost --backfstype=zfs --fsname=zfsmo --index=1 --mgsnode=10.73.20.11@tcp oss2/ost01
-    zfs compression=on oss2
-    zpool export oss2
-```
-
-At this point you should wait until the volume disappears from the volumes page and the dataset appears on both the primary and secondary nodes. Then:
-
-```
-    zpool import oss2
-    mkdir -p /lustre/zfsmo/ost01
-    mount -t lustre oss2/ost01 /lustre/zfsmo/ost01
-```
-
-After all the commands for each node had run successfully, use the IML GUI to scan for the filesystem:
-Configuration -> Servers -> Scan for Filesystem. Use all servers
-
-If Successful, in the IML GUI, the filesystem will be available.
-
-## [Setting up Clients](cd_Setting_Up_Clients.md)
+Clients can be added once the filesystem detection completes. Refer to the following document to [setup clients](cd_Setting_Up_Clients.md) on the new filesystem.
 
 ---
 
-[Top of page](#Top)
+[Top of page](#creating-a-monitored-only-lustre-zfs-filesystem-on-vagrant-hpc-storage-sandbox)

--- a/docs/Contributor_Docs/cd_Monitored_Only_ldiskfs.md
+++ b/docs/Contributor_Docs/cd_Monitored_Only_ldiskfs.md
@@ -1,4 +1,4 @@
-# <a name="Top"></a>Creating a Monitored Only Lustre ldiskfs Filesystem on Vagrant HPC Storage Sandbox
+# Creating a Monitored Only Lustre ldiskfs Filesystem on Vagrant HPC Storage Sandbox
 
 [**Software Contributor Documentation Table of Contents**](cd_TOC.md)
 
@@ -6,167 +6,34 @@
 
 ## Prerequisites:
 
-Please refer to [creating a virtual HPC storage cluster with vagrant](https://github.com/whamcloud/vagrantfiles) before attempting to install IML.
+Create and setup your Vagrant cluster as described in [Installing IML on Vagrant](cd_Installing_IML_On_Vagrant.md)
 
-## Download IML build, create ldiskfs installer, and install ldiskfs packages:
+## Installing Lustre on each MDS and OSS Server
 
-Note: use vagrant ssh-config to get the port each server is running on. The commands below use ports that are specific to my vagrant environment.
+Lustre can now be installed on each mds and oss node.
 
-1.  Verify the following vagrant plugins are installed:
-    ```
-    vagrant plugin install vagrant-shell-commander
-    ```
-2.  Download the latest IML build (tarball).
-    from: [https://github.com/whamcloud/integrated-manager-for-lustre/releases/download/v{{site.version}}/{{site.package_name}}.tar.gz](https://github.com/whamcloud/integrated-manager-for-lustre/releases/download/v{{site.version}}/{{site.package_name}}.tar.gz)
-
-## Installing IML:
-
-1.  Copy the IML build to the /tmp directory in your admin node:
-    ```
-    scp -P 2222 ~/Downloads/{{site.package_name}}.tar.gz vagrant@127.0.0.1:/tmp/.
-    # password is "vagrant"
-    ```
-2.  ssh into the admin box and install the build:
-    ```
-    vagrant ssh
-    [vagrant@adm ~]$ sudo su - # (or "sudo -s")
-    [vagrant@adm ~]# cd /tmp
-    [vagrant@adm ~]# tar xvf <buildname>.tar.gz
-    [vagrant@adm ~]# cd <build folder>
-    [vagrant@adm ~]# ./install --no-dbspace-check
-    ```
-3.  Update the /etc/hosts file on your computer to include the following line:
-    ```
-    127.0.0.1 adm.lfs.local
-    ```
-4.  Test that a connection can be made to IML by going to the following link in your browser:
-    https://adm.lfs.local:8443
-
-## Adding the MDS and OSS Servers
-
-You should now be able to see IML when navigating to https://adm.lfs.local:8443. Click on the login link at the top right and log in as the admin. Next, go to the server configuration page and add the following servers using the "Monitored Server" profile:
-
+```bash
+vagrant provision mds1 mds2 oss1 oss2 --provision-with install-lustre-ldiskfs
 ```
-mds[1,2].lfs.local,oss[1,2].lfs.local
-```
-
-This will take some time (around 5 to 10 minutes) but all four servers should add successfully.
-There will be alerts and warnings about LNET. Ignore for now.
-
-## Installing lustre on each MDS and OSS Server
-
-Lustre server can now be installed on each mds and oss node since the agent software has been deployed. To do this, follow these simple steps:
-
-1.  Create the ldiskfs installer and install the necessary packages on the following servers: mds1, mds2, oss1, and oss2
-    ```
-        cd ~/downloads
-        tar xzvf {{site.package_name}}.tar.gz
-        cd {{site.package_name}}.0
-        ./create_installer ldiskfs
-        for i in {2200..2203}; do scp -P $i ~/Downloads/{{site.package_name}}.0/lustre-ldiskfs-el7-installer.tar.gz vagrant@127.0.0.1:/tmp/.; done
-        # password is "vagrant"
-        vagrant sh -c 'cd /tmp; sudo tar xzvf lustre-ldiskfs-el7-installer.tar.gz; cd lustre-ldiskfs; sudo ./install;' mds1 mds2 oss1 oss2
-        vagrant halt mds1 mds2 oss1 oss2
-        vagrant up mds1 mds2 oss1 oss2
-    ```
-
-## Configuring each MDS and OSS Server
-
-Each server will need to know which interface should be assigned the lustre network.
-Run the following commands:
-
-```
-    vagrant sh -u root -c '
-    systemctl stop firewalld; systemctl disable firewalld;
-    systemctl start ntpd;
-    modprobe lnet
-    lnetctl lnet configure
-    lnetctl net del --net tcp0 --if enp0s3
-    lnetctl net add --net tcp0 --if enp0s9
-    /sbin/modprobe lustre;
-    genhostid' mds1 mds2 oss1 oss2
-```
-
-The IML GUI should show that the LNET and NID Configuration is updated (IP Address 10.73.20.x to use `Lustre Network 0`). All alerts are cleared.
 
 ## Creating a monitored only ldiskfs based Lustre filesystem
 
-When setting up a lustre filesystem, each server must be formatted with the servicenode set to the appropriate nid. Start by creating a mapping of NIDS:
+Run the following vagrant provision script to setup the ldiskfs monitored only filesystem:
 
-```
-vagrant sh -c 'lctl list_nids' mds1 mds2 oss1 oss2
-# Will produce output similar to:
-# mds1::
-# 10.73.20.11@tcp
-# mds2::
-# 10.73.20.12@tcp
-# oss1::
-# 10.73.20.21@tcp
-# oss2::
-# 10.73.20.22@tcp
-#
-# MGS_NID="10.73.20.12@tcp"
-# MDS_NID="10.73.20.11@tcp"
-# OSS1_NID="10.73.20.21@tcp"
-# OSS2_NID="10.73.20.22@tcp"
+```bash
+vagrant provision mds1 mds2 oss1 oss2 --provision-with create-monitored-ldiskfs-filesystem
 ```
 
-### Format the MGS and mount Lustre
+After the provisioning script runs successfully, use the IML GUI to scan for the filesystem:
 
-```
-vagrant sh -u root -c 'mkfs.lustre --mgs --reformat --servicenode=10.73.20.12@tcp \
---servicenode=10.73.20.11@tcp /dev/disk/by-id/ata-VBOX_HARDDISK_MGS00000000000000000' mds2
-vagrant sh -u root -c 'mkdir -p /mnt/mgs' mds1 mds2
-vagrant sh -u root -c 'mount -t lustre /dev/disk/by-id/ata-VBOX_HARDDISK_MGS00000000000000000 /mnt/mgs' mds2
-# verify the mount
-vagrant sh -u root -c 'mount | grep lustre' mds2
-```
+> Configuration -> Servers -> `Detect File Systems`. 
 
-### Format the MDS and mount Lustre
+Click the `Select All` button to select all servers and finally, click on the `Detect File Systems` button to initiate the scan. The filesystem will be listed on the `filesystems` page when the scan completes.
 
-```
-vagrant sh -u root -c 'mkfs.lustre --mdt --reformat --servicenode=10.73.20.12@tcp \
---servicenode=10.73.20.11@tcp --index=0 --mgsnode=10.73.20.12@tcp --fsname=fs \
-/dev/disk/by-id/ata-VBOX_HARDDISK_MDT00000000000000000' mds1
-vagrant sh -u root -c 'mkdir -p /mnt/mds' mds1 mds2
-vagrant sh -u root -c 'mount -t lustre /dev/disk/by-id/ata-VBOX_HARDDISK_MDT00000000000000000 /mnt/mds' mds1
-# verify the mount
-vagrant sh -u root -c 'mount | grep lustre' mds1
-```
+## Setting up Clients
 
-### Format OSS1 and mount Lustre
-
-```
-vagrant sh -u root -c 'mkfs.lustre --ost --reformat --servicenode=10.73.20.21@tcp \
---servicenode=10.73.20.22@tcp --index=0 \
---mgsnode=10.73.20.12@tcp --fsname=fs \
-/dev/disk/by-id/ata-VBOX_HARDDISK_OST0PORT100000000000' oss1
-vagrant sh -u root -c 'mkdir -p /mnt/ost0' oss1 oss2
-vagrant sh -u root -c 'mount -t lustre /dev/disk/by-id/ata-VBOX_HARDDISK_OST0PORT100000000000 /mnt/ost0' oss1
-# verify the mount
-vagrant sh -u root -c 'mount | grep lustre' oss1
-```
-
-### Format OSS2 and mount Lustre
-
-```
-vagrant sh -u root -c 'mkfs.lustre --ost --reformat --servicenode=10.73.20.21@tcp \
---servicenode=10.73.20.22@tcp --index=1 \
---mgsnode=10.73.20.12@tcp --fsname=fs \
-/dev/disk/by-id/ata-VBOX_HARDDISK_OST1PORT200000000000' oss2
-vagrant sh -u root -c 'mkdir -p /mnt/ost1' oss1 oss2
-vagrant sh -u root -c 'mount -t lustre /dev/disk/by-id/ata-VBOX_HARDDISK_OST1PORT200000000000 /mnt/ost1' oss2
-# verify the mount
-vagrant sh -u root -c 'mount | grep lustre' oss2
-```
-
-After all the commands for each node have run successfully, use the IML GUI to scan for the filesystem:
-Configuration -> Servers -> Scan for Filesystem. Use all servers.
-
-If Successful, in the IML GUI, the filesystem will be available.
-
-## [Setting up Clients](cd_Setting_Up_Clients.md)
+Clients can be added once the filesystem detection completes. Refer to the following document to [setup clients](cd_Setting_Up_Clients.md) on the new filesystem.
 
 ---
 
-[Top of page](#Top)
+[Top of page](#creating-a-monitored-only-lustre-ldiskfs-filesystem-on-vagrant-hpc-storage-sandbox)


### PR DESCRIPTION
 Update monitored-only ZFS and ldiskfs

    Fixes #101.
    Fixes #102.

    - Update moniotred only ZFS and ldiskfs
    - Update interface configuration on "Installing IML On Vagrant"

    Signed-off-by: Will Johnson <wjohnson@whamcloud.com>