### PR TITLE
Remove "Setting up Power Control" from Installing IML on Vagrant

### DIFF
--- a/docs/Contributor_Docs/cd_Installing_IML_On_Vagrant.md
+++ b/docs/Contributor_Docs/cd_Installing_IML_On_Vagrant.md
@@ -78,7 +78,3 @@ This will take some time (around 20 to 30 minutes) but all four servers should a
 Once all servers have been added, each server will need to know which interface should be assigned the lustre network. Navigate to each server detail page by clicking on the server link. Scroll to the bottom of the server detail page where you will see a list of network interfaces. Click on the `Configure` button and you will be given the option to change the network driver and the network for each interface.
 
 The vagrant file indicates that the lustre network will run on 10.73.20.x. If `Lustre Network 0` is specified for a different IP address, you will need to change its interface to `Not Lustre Network` and update the network for 10.73.20.x to use `Lustre Network 0`. It is very important that Lustre Network 0 is specified on the correct interface; otherwise, creating a filesystem will fail. Make sure that all servers have been updated where appropriate.
-
-## Setting up Power Control
-
-[Follow these instructions to configure the Power Control.](cd_Setting_Up_Power_Control.md)

--- a/docs/Contributor_Docs/cd_Managed_ZFS.md
+++ b/docs/Contributor_Docs/cd_Managed_ZFS.md
@@ -8,6 +8,10 @@
 
 Create and setup your Vagrant cluster as described in [Installing IML on Vagrant](cd_Installing_IML_On_Vagrant.md)
 
+## Setting up Power Control
+
+[Follow these instructions to configure the Power Control.](cd_Setting_Up_Power_Control.md)
+
 ## Creating Zpools
 
 Now that all managed servers have been added and the power control has been configured, the zpools can be created.


### PR DESCRIPTION
Fixes #103.

We do not need the power control section in this document as it will be included in the docs specific to which kind of filesystem they are creating (ldiskfs, zfs). Remove the "Setting up Power Control" section from Installing IML on Vagrant.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>