### PR TITLE
Link to setups at the bottom of "Installing IML On Vagrant"

### DIFF
--- a/docs/Contributor_Docs/cd_Installing_IML_On_Vagrant.md
+++ b/docs/Contributor_Docs/cd_Installing_IML_On_Vagrant.md
@@ -99,6 +99,16 @@ The interfaces can be configured automatically by running the following script:
  vagrant provision mds1 mds2 oss1 oss2 --provision-with configure-lustre-network
 ```
 
+## Continue with Setup
+
+Select the following options to continue setting up the filesystem:
+
+### [Monitored ZFS](cd_Monitored_Only_ZFS.md)
+
+### [Monitored ldiskfs](cd_Monitored_Only_ldiskfs.md)
+
+### [Managed ZFS](cd_Managed_ZFS.md)
+
 ---
 
 [Top of page](#installing-iml-on-vagrant)


### PR DESCRIPTION
Fixes #111.

The Installing IML On Vagrant document should link to the following setup documents:

Managed ZFS
Monitored Only ZFS
Monitored Only Ldiskfs

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>