### PR TITLE
Emphasize location constraint in upgrade docs from 2.4 to 4.x

### DIFF
--- a/docs/Upgrade_Guide/Upgrade_EE-2.4-el6_to_LU-LTS-el7.md
+++ b/docs/Upgrade_Guide/Upgrade_EE-2.4-el6_to_LU-LTS-el7.md
@@ -1043,7 +1043,7 @@ The `pcs config export` command can be useful as a cross reference when restorin
     cibadmin -o constraints -C -X '<rsc_location id="<resource>-secondary" node="<secondary node name>" rsc="<resource>" score="10" />'
     ```
 
-    The information for each constraint is acquired from the CIB XML backup as follows:
+    Note that the id **must** have either `-primary` or `-secondary` following the resource's HA label. The information for each constraint is acquired from the CIB XML backup as follows:
 
     ```bash
     pcs -f $HOME/bck-`hostname`-*/cluster-cfg-`hostname`.xml constraint show


### PR DESCRIPTION
We have encountered two cases in which the location was not "primary" or
"secondary" when the location constraints are defined. Add a note to
emphasize that -primary or -secondary must be specified.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>