### PR TITLE
Fix baseurl in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,6 @@ ifeq ($(UNPUBLISHED),true)
   PACKAGE_RELEASE := $(SCM_COMMIT_NUMBER).$(PACKAGE_RELEASE)
 endif
 
-BASEURL ?= $(PWD)/targetdir
-
 MD_FILES    := $(shell find docs -name \*.md)
 OTHER_FILES := $(shell find docs -name \*.png -name \*.css)
 HTML_FILES  := $(addprefix targetdir/,$(patsubst %.md,%.html,$(MD_FILES))) \
@@ -20,12 +18,9 @@ DISTCLEAN   += vendor
 # the ".html" for "%html" to effectively turn this into a multiple
 # matching target pattern rule
 $(subst .html,%html,$(HTML_FILES)): vendor/cache $(SOURCES)
-	bundle exec jekyll build --destination targetdir --baseurl \
-	    $(BASEURL) --incremental
+	bundle exec jekyll build --destination targetdir --baseurl '/help' \
+	    --incremental
 	find targetdir -name \*.md -print0 | xargs -0 rm -f
-
-view: targetdir
-	google-chrome-stable --new-window file://$$PWD/targetdir/index.html
 
 vendor/cache: Gemfile Gemfile.lock
 	bundle install --path vendor/cache


### PR DESCRIPTION
The baseurl field in the online-help makefile
is incorrectly referring to BASEURL as `$(PWD)/targetdir`.

This is causing the CSS and images to all 404
when we try to load a page from the online-help rpm.

Fix this, and also remove the view target, which we aren't using.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>