### PR TITLE
Move Offline repo doc

### DIFF
--- a/docs/IML_Help_TOC.md
+++ b/docs/IML_Help_TOC.md
@@ -15,7 +15,6 @@
 - [Detecting and monitoring existing Lustre file systems](Detect_and_monitor_existing_LFS_7_0.md)
 - [Creating and Managing ZFS-based Lustre file systems](Create_and_manage_ZFS_based_LFS_8_0.md)
 - [Graphical User Interface](Graphical_User_Interface_9_0.md)
-- [How to create offline repos for IML {{site.version}}](Create_Offline_Repos_10_0.md)
 - [Advanced topics](Advanced_Topics_11_0.md)
 - [Using the Integrated Manager for Lustre software command line interface](Using_IML_CLI_12_0.md)
 - [Errors and troubleshooting](Errors_Troubleshooting_13_0.md)

--- a/docs/Install_Guide/Create_Offline_Repos_10_0.md
+++ b/docs/Install_Guide/Create_Offline_Repos_10_0.md
@@ -1,6 +1,6 @@
 # How to create offline repos for IML {{site.version}}
 
-[**Online Help Table of Contents**](IML_Help_TOC.md)
+[**Software Installation Guide Table of Contents**](ig_TOC.md)
 
 The following is a procedure for creating local repos using a CentOS 7 VM.
 

--- a/docs/Install_Guide/ig_TOC.md
+++ b/docs/Install_Guide/ig_TOC.md
@@ -8,6 +8,7 @@
 
 - [About this Document](ig_ch_01_about.md)
 - [Introducing the Integrated Manager for Lustre software](ig_ch_02_introduction.md)
+- [How to create offline repos for IML {{site.version}}](Create_Offline_Repos_10_0.md)
 - [Building the System – The High Availability Configuration Spec](ig_ch_03_building.md)
 - [Pre-Installation Tasks](ig_ch_04_pre_install.md)
 - [Integrated Manager for Lustre software Installation](ig_ch_05_install.md)


### PR DESCRIPTION
The offline repo doc is currently under the online help section, but it
makes more sense for it to be under the install guide section.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>