### PR TITLE
Update uninstall instructions for the agent side

### DIFF
--- a/docs/Contributor_Docs/cd_UnInstall_IML.md
+++ b/docs/Contributor_Docs/cd_UnInstall_IML.md
@@ -105,6 +105,7 @@ yum remove -y chroma-agent chroma-agent-management iml_sos_plugin iml-device-sca
 rm -rf /etc/yum.repos.d/Intel-Lustre-Agent.repo
 rm -rf /var/lib/chroma/
 rm -rf /var/lib/iml/
+rm -rf /etc/iml/
 rm -rf /etc/yum.repos.d/Intel-Lustre-Agent.repo
 rm -rf /usr/lib/python2.7/site-packages/chroma_agent*
 ```


### PR DESCRIPTION
Starting in IML 5.0.0 files have been added to the /etc/iml/ directory.
If this folder is not removed after uninstalling and then the server is
used again it will contain cached data that will prevent volumes from
being picked up by iml. This patch updates the "Remove Agent Software"
section to ensure that this directory is removed.

Signed-off-by: johnsonw <wjohnson@whamcloud.com>