### PR TITLE
 fix: Remove -h help option from  server add

### DIFF
--- a/docs/Contributor_Docs/cd_Running_IML_On_Docker_With_Vagrant_Servers.md
+++ b/docs/Contributor_Docs/cd_Running_IML_On_Docker_With_Vagrant_Servers.md
@@ -131,7 +131,7 @@ vagrant provision mds1 mds2 oss1 oss2 --provision-with configure-docker-network
 We can now deploy monitored servers with the following command on the host
 
 ```sh
-iml server add -h mds[1,2].local,oss[1,2].local -p  base_monitored
+iml server add mds[1,2].local,oss[1,2].local -p  base_monitored
 ```
 
 Next create some ldiskfs filesystems with the following provisioner


### PR DESCRIPTION
Option -h in iml server add leads to help output

    According to options description:
    FLAGS:
        -h, --help       Prints help information